### PR TITLE
Add proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # duckflight
 
-A simple [Arrow Flight SQL](https://arrow.apache.org/docs/format/FlightSql.html) server to allow DuckDB 
+A simple [Arrow Flight SQL](https://arrow.apache.org/docs/format/FlightSql.html) server & proxy to allow DuckDB 
 to be queried remotely using the [Arrow Flight SQL JDBC Driver](https://arrow.apache.org/docs/java/flight_sql_jdbc_driver.html).
 
-This project uses Java 20.
+Note that the proxying is a rough proof-of-concept.
+
+To run
+* Start the server by passing "server" as the command line argument.
+* Start the proxy by passing "proxy" as the argument.
+* Run the client by passing "client" as the argument.
+
+This project uses Java 17.

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>20</maven.compiler.source>
-        <maven.compiler.target>20</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <arrow.version>13.0.0</arrow.version>

--- a/src/main/java/com/mode/ryankennedy/duckflight/Client.java
+++ b/src/main/java/com/mode/ryankennedy/duckflight/Client.java
@@ -1,0 +1,51 @@
+package com.mode.ryankennedy.duckflight;
+
+import org.apache.arrow.flight.Location;
+
+import java.sql.*;
+
+public class Client {
+
+    private final Location location;
+
+    public Client(Location location) {
+        this.location = location;
+    }
+
+    public void query() {
+        // Generate a JDBC connection using the Arrow Flight SQL JDBC driver
+        try (var connection = getConnection();
+             var statement = connection.createStatement();
+             // Attempt to query the information schema
+             var results = executeQuery(statement)) {
+                consumeResults(results);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Connection getConnection() throws SQLException {
+        // Connect to the Arrow Flight SQL server using token authentication and no encryption
+        return DriverManager.getConnection("jdbc:arrow-flight-sql://%s:%d/?%s".formatted(
+                location.getUri().getHost(),
+                location.getUri().getPort(),
+                "token=token_1&useEncryption=false"));
+    }
+
+    private void consumeResults(ResultSet results) throws SQLException {
+        // Output the column names and values for each row
+        var metaData = results.getMetaData();
+        while (results.next()) {
+            System.out.printf("Row #%d%n", results.getRow());
+            for (int i = 1; i <= metaData.getColumnCount(); i++) {
+                System.out.printf("    %s: %s%n", metaData.getColumnName(i), results.getString(i));
+            }
+        }
+    }
+
+    private ResultSet executeQuery(Statement statement) throws SQLException {
+        // Query the information schema's `schemata` table, which is one of the few with rows in
+        // it after connecting to a fresh DuckDB instance
+        return statement.executeQuery("select * from information_schema.schemata");
+    }
+}

--- a/src/main/java/com/mode/ryankennedy/duckflight/Proxy.java
+++ b/src/main/java/com/mode/ryankennedy/duckflight/Proxy.java
@@ -1,0 +1,132 @@
+package com.mode.ryankennedy.duckflight;
+
+import io.grpc.*;
+import io.grpc.stub.StreamObserver;
+import org.apache.arrow.flight.impl.Flight;
+import org.apache.arrow.flight.impl.FlightServiceGrpc;
+import org.apache.arrow.flight.Location;
+
+import java.io.IOException;
+
+import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
+
+public class Proxy {
+    public static final Location LOCATION = Location.forGrpcInsecure("0.0.0.0", 3001);
+
+    private static final Metadata.Key<String> AUTHORIZATION_METADATA_KEY = Metadata.Key.of("Authorization", ASCII_STRING_MARSHALLER);
+    private static final Context.Key<String> WORKSPACE_TOKEN_KEY = Context.key("WorkspaceToken");
+
+    private final FlightServiceGrpc.FlightServiceBlockingStub client;
+
+    public Proxy(String serverHost, int serverPort) throws InterruptedException, IOException {
+        var channel = Grpc.newChannelBuilder(serverHost + ":" + serverPort, InsecureChannelCredentials.create())
+                .build();
+        this.client = FlightServiceGrpc.newBlockingStub(channel)
+                .withInterceptors(new ClientWorkspaceTokenInterceptor());
+
+        var server = Grpc.newServerBuilderForPort(3001, InsecureServerCredentials.create())
+                .addService(new GrpcServer())
+                .intercept(new ServerWorkspaceTokenInterceptor())
+                .build()
+                .start();
+        server.awaitTermination();
+    }
+
+    private class GrpcServer extends FlightServiceGrpc.FlightServiceImplBase {
+
+        @Override
+        public void doAction(Flight.Action request, StreamObserver<Flight.Result> responseObserver) {
+            var token = WORKSPACE_TOKEN_KEY.get();
+            System.out.println("Proxy.GrpcServer.doAction (Token: " + token + ") - " + request.toString());
+            try {
+                var results = client.doAction(request);
+                while (results.hasNext()) {
+                    responseObserver.onNext(results.next());
+                }
+                responseObserver.onCompleted();
+            } catch (Exception e) {
+                System.out.println("  Exception - " + e.getMessage());
+                responseObserver.onError(e);
+            }
+        }
+
+        @Override
+        public void doGet(Flight.Ticket request, StreamObserver<Flight.FlightData> responseObserver) {
+            System.out.println("Proxy.GrpcServer.doGet - " + request);
+            try {
+                var flightData = client.doGet(request);
+                while (flightData.hasNext()) {
+                    responseObserver.onNext(flightData.next());
+                }
+                responseObserver.onCompleted();
+            } catch (Exception e) {
+                System.out.println("  Exception - " + e.getMessage());
+                responseObserver.onError(e);
+            }
+        }
+
+        @Override
+        public void getFlightInfo(Flight.FlightDescriptor request, StreamObserver<Flight.FlightInfo> responseObserver) {
+            System.out.println("Proxy.GrpcServer.getFlightInfo - " + request);
+            try {
+                responseObserver.onNext(client.getFlightInfo(request));
+                responseObserver.onCompleted();
+            } catch (Exception e) {
+                System.out.println("  Exception - " + e.getMessage());
+                responseObserver.onError(e);
+            }
+        }
+
+        @Override
+        public StreamObserver<Flight.HandshakeRequest> handshake(StreamObserver<Flight.HandshakeResponse> responseObserver) {
+            System.out.println("Proxy.GrpcServer.handshake");
+            // TODO: no idea if this is correct
+            var response = Flight.HandshakeResponse.getDefaultInstance();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+            return null;
+        }
+
+        @Override
+        public void listFlights(Flight.Criteria request, StreamObserver<Flight.FlightInfo> responseObserver) {
+            System.out.println("Proxy.GrpcServer.listFlights");
+            try {
+                var flights = client.listFlights(request);
+                while (flights.hasNext()) {
+                    responseObserver.onNext(flights.next());
+                }
+                responseObserver.onCompleted();
+            } catch (Exception e) {
+                System.out.println("  Exception - " + e.getMessage());
+                responseObserver.onError(e);
+            }
+        }
+    }
+
+    private static class ServerWorkspaceTokenInterceptor implements ServerInterceptor {
+
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+            var token = headers.get(AUTHORIZATION_METADATA_KEY);
+            System.out.println("Server Intercepted - Token: " + token);
+            var ctx = Context.current()
+                    .withValue(WORKSPACE_TOKEN_KEY, token.replace("Bearer ", ""));
+            return Contexts.interceptCall(ctx, call, headers, next);
+        }
+    }
+
+    private static class ClientWorkspaceTokenInterceptor implements ClientInterceptor {
+
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+            System.out.println("Client Intercepted");
+            return new ForwardingClientCall.SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+                @Override
+                public void start(Listener<RespT> responseListener, Metadata headers) {
+                    headers.put(AUTHORIZATION_METADATA_KEY, "Bearer " + WORKSPACE_TOKEN_KEY.get());
+                    super.start(responseListener, headers);
+                }
+            };
+        }
+    }
+}

--- a/src/main/java/com/mode/ryankennedy/duckflight/authenticator/BearerTokenCallHeaderAuthenticator.java
+++ b/src/main/java/com/mode/ryankennedy/duckflight/authenticator/BearerTokenCallHeaderAuthenticator.java
@@ -13,6 +13,7 @@ public class BearerTokenCallHeaderAuthenticator implements CallHeaderAuthenticat
     public AuthResult authenticate(CallHeaders incomingHeaders) {
         var bearerToken = AuthUtilities.getValueFromAuthHeader(incomingHeaders, Auth2Constants.BEARER_PREFIX);
         if (bearerToken != null) {
+            System.out.println("Received bearer token: " + bearerToken);
             // TODO: Utilize a cache to minimize calls to webapp
             // TODO: Make the call to webapp to validate
             return () -> bearerToken;


### PR DESCRIPTION
This splits the code into 3 main pieces
`Client.java` which contains the JDBC driver calls
`Proxy.java` which creates a gRPC server to catch the gRPC calls from the JDBC client and relay them to the server
`Server.java` instantiates the DuckDB instance and executed the Arrow Flight SQL queries.
 
The proxy also demonstrates the ability to get the workspace token from the HTTP headers. This can be used to proxy the request to different servers. The code also puts the `Authorization` header back onto the proxy call to the server to handle authentication.

Client header setting taken from https://github.com/grpc/grpc-java/blob/master/examples/src/main/java/io/grpc/examples/header/HeaderClientInterceptor.java. Server header extraction code based off https://github.com/grpc/grpc-java/blob/f4cda008ee1c0e10de8575e1b4be6841d5364b72/examples/example-jwt-auth/src/main/java/io/grpc/examples/jwtauth/JwtServerInterceptor.java.

This is just a proof of concept to show that proxying can be done. The proxy class is using a blocking client which may not be performant enough in production. Also, I'm not sure how thread-safe the calls into the context to get/set the saved header values are. Finally, I have no clue if the `handshake` implementation is even remotely correct, but it does enough to not throw exceptions.

The grpc-java repo has an example of a gRPC proxy, https://github.com/grpc/grpc-java/blob/master/examples/src/main/java/io/grpc/examples/grpcproxy/GrpcProxy.java, but I think this would be too inflexible for our needs as we'd need to dynamically pick servers based off persistent storage (read: DynamoDB) lookups.

Using this approach for proxying will require extensive integration tests to ensure that all cases are handled (i.e., exceptions, servers going down, etc.) and to make sure the proxy continues to work on Arrow Flight upgrades.



